### PR TITLE
feat: add common timeout for some operations that could be tweaked

### DIFF
--- a/archives/config.go
+++ b/archives/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	MaxConcurrentArchivation int `help:"max concurrent org archivation (default 2)"`
 
 	ArchiveInactive bool `help:"archive inactive orgs (default false)"`
+
+	CommonTimeout int `help:"common timeout for many operations, limit in minutes (default 5)"`
 }
 
 // NewConfig returns a new default configuration object
@@ -66,6 +68,8 @@ func NewConfig() *Config {
 		MaxConcurrentArchivation: 2,
 
 		ArchiveInactive: false,
+
+		CommonTimeout: 5,
 	}
 
 	return &config

--- a/archives/messages.go
+++ b/archives/messages.go
@@ -239,7 +239,7 @@ func DeleteArchivedMessages(ctx context.Context, config *Config, db *sqlx.DB, s3
 		cancel()
 	}
 
-	outer, cancel = context.WithTimeout(ctx, time.Minute)
+	outer, cancel = context.WithTimeout(ctx, time.Minute*time.Duration(config.CommonTimeout))
 	defer cancel()
 
 	deletedOn := time.Now()

--- a/archives/runs.go
+++ b/archives/runs.go
@@ -213,7 +213,7 @@ func DeleteArchivedRuns(ctx context.Context, config *Config, db *sqlx.DB, s3Clie
 		cancel()
 	}
 
-	outer, cancel = context.WithTimeout(ctx, time.Minute)
+	outer, cancel = context.WithTimeout(ctx, time.Minute*time.Duration(config.CommonTimeout))
 	defer cancel()
 
 	deletedOn := time.Now()


### PR DESCRIPTION
some operations get timeout exceeded, with this feature we can configure more generous timeout for some simple operations that got more time to execute with more than one goroutine doing the same operation.