### PR TITLE
feat: orgs prioritization

### DIFF
--- a/archives/archives.go
+++ b/archives/archives.go
@@ -97,6 +97,7 @@ LEFT JOIN (
     SELECT DISTINCT ON (org_id) org_id, record_count
     FROM archives_archive
     WHERE period = 'M'
+	AND archive_type = 'message'
     ORDER BY org_id, start_date DESC
 ) latest_archive ON latest_archive.org_id = o.id
 WHERE o.is_active = TRUE 

--- a/archives/archives.go
+++ b/archives/archives.go
@@ -93,13 +93,12 @@ func (a *Archive) endDate() time.Time {
 const lookupActiveOrgs = `
 SELECT o.id, o.name, o.created_on, o.is_anon 
 FROM orgs_org o 
-LEFT JOIN LATERAL (
-    SELECT a.record_count
-    FROM archives_archive a
-    WHERE a.org_id = o.id AND a.period = 'M'
-    ORDER BY a.start_date DESC
-    LIMIT 1
-) latest_archive ON true
+LEFT JOIN (
+    SELECT DISTINCT ON (org_id) org_id, record_count
+    FROM archives_archive
+    WHERE period = 'M'
+    ORDER BY org_id, start_date DESC
+) latest_archive ON latest_archive.org_id = o.id
 WHERE o.is_active = TRUE 
 ORDER BY COALESCE(latest_archive.record_count, 0) DESC, o.id
 `

--- a/archives/archives.go
+++ b/archives/archives.go
@@ -93,7 +93,15 @@ func (a *Archive) endDate() time.Time {
 const lookupActiveOrgs = `
 SELECT o.id, o.name, o.created_on, o.is_anon 
 FROM orgs_org o 
-WHERE o.is_active = TRUE order by o.id
+LEFT JOIN LATERAL (
+    SELECT a.record_count
+    FROM archives_archive a
+    WHERE a.org_id = o.id AND a.period = 'M'
+    ORDER BY a.start_date DESC
+    LIMIT 1
+) latest_archive ON true
+WHERE o.is_active = TRUE 
+ORDER BY COALESCE(latest_archive.record_count, 0) DESC, o.id
 `
 
 const lookupInactiveOrgs = `
@@ -102,7 +110,7 @@ FROM orgs_org o
 WHERE o.is_active = FALSE order by o.id
 `
 
-// GetActiveOrgs returns the active organizations sorted by id
+// GetActiveOrgs returns the active organizations sorted by most recent monthly archive record count (descending)
 func GetActiveOrgs(ctx context.Context, db *sqlx.DB, conf *Config) ([]Org, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()

--- a/archives/archives_test.go
+++ b/archives/archives_test.go
@@ -30,6 +30,51 @@ func setup(t *testing.T) *sqlx.DB {
 	return db
 }
 
+func TestGetActiveOrgsOrdering(t *testing.T) {
+	db := setup(t)
+	ctx := context.Background()
+	config := NewConfig()
+
+	// with default test data all orgs have monthly record_count=0, so tiebreaker is o.id
+	orgs, err := GetActiveOrgs(ctx, db, config)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(orgs))
+	assert.Equal(t, 1, orgs[0].ID)
+	assert.Equal(t, 2, orgs[1].ID)
+	assert.Equal(t, 3, orgs[2].ID)
+
+	// insert monthly archives: Org 2 gets 500, Org 1 gets 100 (Org 3 already has 0)
+	_, err = db.Exec(`
+		INSERT INTO archives_archive(archive_type, created_on, start_date, period, record_count, size, hash, url, needs_deletion, build_time, org_id) VALUES
+		('message', '2017-12-01 00:00:00+00', '2017-12-01', 'M', 100, 0, '', '', FALSE, 0, 1),
+		('message', '2017-12-01 00:00:00+00', '2017-12-01', 'M', 500, 0, '', '', FALSE, 0, 2)
+	`)
+	assert.NoError(t, err)
+
+	// ordering should now be: Org 2 (500), Org 1 (100), Org 3 (0)
+	orgs, err = GetActiveOrgs(ctx, db, config)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(orgs))
+	assert.Equal(t, 2, orgs[0].ID)
+	assert.Equal(t, 1, orgs[1].ID)
+	assert.Equal(t, 3, orgs[2].ID)
+
+	// add a more recent monthly archive for Org 3 with highest record_count
+	_, err = db.Exec(`
+		INSERT INTO archives_archive(archive_type, created_on, start_date, period, record_count, size, hash, url, needs_deletion, build_time, org_id) VALUES
+		('message', '2018-01-01 00:00:00+00', '2018-01-01', 'M', 1000, 0, '', '', FALSE, 0, 3)
+	`)
+	assert.NoError(t, err)
+
+	// ordering should now be: Org 3 (1000), Org 2 (500), Org 1 (100)
+	orgs, err = GetActiveOrgs(ctx, db, config)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(orgs))
+	assert.Equal(t, 3, orgs[0].ID)
+	assert.Equal(t, 2, orgs[1].ID)
+	assert.Equal(t, 1, orgs[2].ID)
+}
+
 func TestGetMissingDayArchives(t *testing.T) {
 	db := setup(t)
 


### PR DESCRIPTION
**Motivação**

A lista de organizações ativas retornada pelo archiver era ordenada simplesmente por id. Isso não priorizava orgs com maior volume de dados, o que pode ser relevante para otimizar o tempo total de arquivamento processando primeiro as organizações mais pesadas.

**Alterações**
1. Modificada a query lookupActiveOrgs para fazer um LEFT JOIN LATERAL com a tabela archives_archive, buscando o record_count do archive mensal (period = 'M') mais recente de cada org.
2. A ordenação agora é COALESCE(record_count, 0) DESC, o.id — orgs com maior volume mensal são processadas primeiro, com desempate por id.
3. Orgs sem nenhum archive mensal são tratadas com record_count = 0 e ficam ao final da lista.

**Testes**

1. Adicionado o teste TestGetActiveOrgsOrdering que valida:
> Ordenação padrão (todas com record_count = 0, desempate por id)
> Ordenação após inserção de archives mensais com record_count diferentes
> Ordenação correta quando um archive mensal mais recente é inserido com record_count mais alto
2. Testes existentes não foram afetados pois os dados de teste padrão mantêm a mesma ordem.